### PR TITLE
Fix ignored test cases

### DIFF
--- a/src/test/java/com/amazon/pvar/tspoc/merlin/AbstractCallGraphTest.java
+++ b/src/test/java/com/amazon/pvar/tspoc/merlin/AbstractCallGraphTest.java
@@ -16,6 +16,8 @@
 package com.amazon.pvar.tspoc.merlin;
 
 import com.amazon.pvar.tspoc.merlin.experiments.Main;
+import com.amazon.pvar.tspoc.merlin.solver.MerlinSolverFactory;
+import com.amazon.pvar.tspoc.merlin.solver.querygraph.QueryGraph;
 import dk.brics.tajs.flowgraph.FlowGraph;
 import dk.brics.tajs.flowgraph.jsnodes.Node;
 import org.junit.Before;
@@ -44,4 +46,9 @@ public class AbstractCallGraphTest {
                 .orElseThrow();
     }
 
+    @Before
+    public void setup() {
+        MerlinSolverFactory.reset();
+        QueryGraph.reset();
+    }
 }

--- a/src/test/java/com/amazon/pvar/tspoc/merlin/InterproceduralPointsToTests.java
+++ b/src/test/java/com/amazon/pvar/tspoc/merlin/InterproceduralPointsToTests.java
@@ -23,7 +23,6 @@ import dk.brics.tajs.flowgraph.jsnodes.CallNode;
 import dk.brics.tajs.flowgraph.jsnodes.ConstantNode;
 import dk.brics.tajs.flowgraph.jsnodes.DeclareFunctionNode;
 import dk.brics.tajs.flowgraph.jsnodes.NewObjectNode;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import sync.pds.solver.nodes.Node;
@@ -51,12 +50,6 @@ public class InterproceduralPointsToTests extends AbstractCallGraphTest{
     public void initializeQueryGraph(MerlinSolver solver) {
         MerlinSolverFactory.addNewActiveSolver(solver);
         QueryGraph.getInstance().setRoot(solver);
-    }
-
-    @Before
-    public void setup() {
-        MerlinSolverFactory.reset();
-        QueryGraph.reset();
     }
 
     @Test
@@ -188,7 +181,7 @@ public class InterproceduralPointsToTests extends AbstractCallGraphTest{
     }
 
     @Test
-    @Ignore
+    @Ignore // Will fail until datalog-style solver is implemented (leads to query graph cycle)
     public void findMultipleHigherOrderCallSites() {
         FlowGraph flowGraph =
                 initializeFlowgraph("src/test/resources/js/callgraph/interprocedural-tests/higherOrder2.js");
@@ -300,7 +293,7 @@ public class InterproceduralPointsToTests extends AbstractCallGraphTest{
     }
 
     @Test
-    @Ignore
+    @Ignore // Will fail until heap manipulation is supported
     public void paramClosureMultiUse() {
         FlowGraph flowGraph =
                 initializeFlowgraph("src/test/resources/js/callgraph/interprocedural-tests/closureParamMultipleUsage.js");
@@ -441,7 +434,8 @@ public class InterproceduralPointsToTests extends AbstractCallGraphTest{
     }
 
     @Test
-    @Ignore
+    @Ignore // TODO: Discuss this test case. Currently fails because Merlin does not distinguish function declarations
+            //  by context.
     public void multipleContextClosureCallReturn() {
         FlowGraph flowGraph =
                 initializeFlowgraph("src/test/resources/js/callgraph/interprocedural-tests/closureCallReturnMultContexts.js");

--- a/src/test/java/com/amazon/pvar/tspoc/merlin/IntraproceduralPointsToTests.java
+++ b/src/test/java/com/amazon/pvar/tspoc/merlin/IntraproceduralPointsToTests.java
@@ -19,13 +19,14 @@ import com.amazon.pvar.tspoc.merlin.ir.*;
 import com.amazon.pvar.tspoc.merlin.solver.BackwardMerlinSolver;
 import com.amazon.pvar.tspoc.merlin.solver.CallGraph;
 import com.amazon.pvar.tspoc.merlin.solver.ForwardMerlinSolver;
+import com.amazon.pvar.tspoc.merlin.solver.MerlinSolverFactory;
 import com.amazon.pvar.tspoc.merlin.solver.PointsToGraph;
+import com.amazon.pvar.tspoc.merlin.solver.querygraph.QueryGraph;
 import dk.brics.tajs.flowgraph.FlowGraph;
 import dk.brics.tajs.flowgraph.jsnodes.CallNode;
 import dk.brics.tajs.flowgraph.jsnodes.ConstantNode;
 import dk.brics.tajs.flowgraph.jsnodes.DeclareFunctionNode;
 import dk.brics.tajs.flowgraph.jsnodes.NewObjectNode;
-import org.junit.Ignore;
 import org.junit.Test;
 import sync.pds.solver.nodes.Node;
 
@@ -92,7 +93,6 @@ public class IntraproceduralPointsToTests extends AbstractCallGraphTest {
     }
 
     @Test
-    @Ignore
     public void forwardQueryFuncAssign() {
         FlowGraph flowGraph =
                 initializeFlowgraph("src/test/resources/js/callgraph/intraprocedural-tests/intraproceduralFunctionPropagation.js");
@@ -106,6 +106,8 @@ public class IntraproceduralPointsToTests extends AbstractCallGraphTest {
         );
 
         ForwardMerlinSolver solver = new ForwardMerlinSolver(callGraph, pointsTo, initialQuery);
+        MerlinSolverFactory.addNewActiveSolver(solver);
+        QueryGraph.getInstance().setRoot(solver);
         solver.solve();
         Collection<PointsToGraph.PointsToLocation> pts = pointsTo.getKnownValuesPointingTo(allocation);
         Collection<CallNode> invokes = pointsTo.getKnownFunctionInvocations(allocation);
@@ -115,7 +117,6 @@ public class IntraproceduralPointsToTests extends AbstractCallGraphTest {
     }
 
     @Test
-    @Ignore
     public void forwardQueryFuncDecl() {
         FlowGraph flowGraph =
                 initializeFlowgraph("src/test/resources/js/callgraph/intraprocedural-tests/intraproceduralFunctionDecl.js");
@@ -129,6 +130,8 @@ public class IntraproceduralPointsToTests extends AbstractCallGraphTest {
         );
 
         ForwardMerlinSolver solver = new ForwardMerlinSolver(callGraph, pointsTo, initialQuery);
+        MerlinSolverFactory.addNewActiveSolver(solver);
+        QueryGraph.getInstance().setRoot(solver);
         solver.solve();
         Collection<PointsToGraph.PointsToLocation> pts = pointsTo.getKnownValuesPointingTo(allocation);
         Collection<CallNode> invokes = pointsTo.getKnownFunctionInvocations(allocation);


### PR DESCRIPTION
*Issue #, if available:*
Ignored test cases task

*Description of changes:*
- Updated five previously-ignored test cases to use Merlin's `MerlinSolverFactory` and `QueryGraph` API. The tests now pass and the `@Ignore` flag has been removed.
- Added descriptions to the three remaining ignored test cases
- Pulled the `setup()` method up from `InterproceduralPointsToTests` to `AbstractCallGraphTest`, since it should be run `@Before` all tests, not just interprocedural tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
