### PR TITLE
Support ES5+ constructs via Babel in TAJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ ES5 language features are supported at the moment.
 
 ## Building and Running
 
+### Installing dependencies
 First, check out the submodules by running `git submodule update --init --recursive`.
+
+Then you will need `npm` installed. We recommend using [Node Version Manager (nvm)](https://github.com/nvm-sh/nvm) to install node and npm. Once installed, run:
+`cd tajs_vr/extras/babel`
+`npm install`
 
 This project is built via [sbt](https://www.scala-sbt.org). Please follow the official [instructions](https://www.scala-sbt.org/1.x/docs/Setup.html) for installing sbt.
 
@@ -27,6 +32,8 @@ For example, if you are using using the Amazon Coretto SDK on Mac OSX, the follo
 -java-home
 /Library/Java/JavaVirtualMachines/amazon-corretto-16.jdk/Contents/Home
 ```
+
+### Running Merlin
 
 After that, the project can be built by running `sbt compile` and run via `sbt run`.
 

--- a/src/test/java/com/amazon/pvar/tspoc/merlin/FlowFunctionTests.java
+++ b/src/test/java/com/amazon/pvar/tspoc/merlin/FlowFunctionTests.java
@@ -428,6 +428,7 @@ public class FlowFunctionTests extends AbstractCallGraphTest{
         logTest(wvn, val2, nextStates2, false);
     }
 
+    @Ignore("Does not work if babel is enabled since unsupported.js contains a `with` and babel is in strict mode which forbids `with`")
     @Test
     public void testUnsupportedBackward() {
         FlowGraph flowGraph =
@@ -444,6 +445,7 @@ public class FlowFunctionTests extends AbstractCallGraphTest{
         logTest(bwn, val, nextStates, true);
     }
 
+    @Ignore("Does not work if babel is enabled since unsupported.js contains a `with` and babel is in strict mode which forbids `with`")
     @Test
     public void testUnsupportedForward() {
         FlowGraph flowGraph =


### PR DESCRIPTION
**Motivation:**

Some of the tests we are running use features that were introduced in ES6 and above. We want to preserve these tests, but make them compatible with TAJS. Thus in this change we introduced the use of `-babel` when creating the flowgraph so that TAJS downcompiles the code to ES5 (using babel) before creating the flowgraph

**Assumptions/Open issues:**

* Two additional tests (FlowFunctionTests.testUnsupportedForward and FlowFunctionTests.testUnsupportedBackward) are disabled since babel parsing is incompatible with them. Idea is to re-enable them using a different language feature that is supported by babel but not supported by Merlin

**Testing:**

* sbt test

**Issue Link**

N/A

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
