### PR TITLE
Fix closure handling in backward flow functions

### DIFF
--- a/src/main/java/com/amazon/pvar/tspoc/merlin/solver/flowfunctions/BackwardFlowFunctions.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/solver/flowfunctions/BackwardFlowFunctions.java
@@ -498,9 +498,9 @@ public class BackwardFlowFunctions extends AbstractFlowFunctions {
                 if (!queryVar.isVisibleIn(invokeScope)) {
                     // If QueryVar isn't visible at the call site, we should move out one scope from the current
                     // function and find what queryVar could point to in the invocation scope.
-                    getPredecessors(containingFunction.getNode()).forEach(pred -> {
-                        addSingleState(pred, queryVar);
-                    });
+                    Node outerScopeReturnNode =
+                            ((Node) containingFunction.getNode().getBlock().getFunction().getOrdinaryExit().getFirstNode());
+                    addSingleState(outerScopeReturnNode, queryVar);
                 } else {
                     addCallPopState(invoke, queryVar);
                 }

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/solver/flowfunctions/BackwardFlowFunctions.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/solver/flowfunctions/BackwardFlowFunctions.java
@@ -18,6 +18,7 @@ package com.amazon.pvar.tspoc.merlin.solver.flowfunctions;
 import com.amazon.pvar.tspoc.merlin.ir.*;
 import com.amazon.pvar.tspoc.merlin.solver.BackwardMerlinSolver;
 import com.amazon.pvar.tspoc.merlin.solver.CallGraph;
+import com.amazon.pvar.tspoc.merlin.solver.MerlinSolver;
 import com.amazon.pvar.tspoc.merlin.solver.MerlinSolverFactory;
 import com.amazon.pvar.tspoc.merlin.solver.PointsToGraph;
 import com.amazon.pvar.tspoc.merlin.solver.querygraph.QueryGraph;
@@ -25,6 +26,11 @@ import dk.brics.tajs.flowgraph.AbstractNode;
 import dk.brics.tajs.flowgraph.Function;
 import dk.brics.tajs.flowgraph.jsnodes.*;
 import dk.brics.tajs.js2flowgraph.FlowGraphBuilder;
+import sync.pds.solver.SyncPDSSolver;
+import sync.pds.solver.SyncPDSUpdateListener;
+import sync.pds.solver.nodes.CallPopNode;
+import sync.pds.solver.nodes.NodeWithLocation;
+import sync.pds.solver.nodes.PopNode;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -482,44 +488,23 @@ public class BackwardFlowFunctions extends AbstractFlowFunctions {
             invokes.forEach(invoke -> {
                 try {
                     Register reg = new Register(invoke.getArgRegister(paramIndex), invoke.getBlock().getFunction());
-                    addCallPopState(invoke, reg);
+                    addSingleState(invoke, reg);
                 } catch (ArrayIndexOutOfBoundsException e) {}
             });
         } else {
-            // Step backward from the invocation
-            Function declaringFunction = queryVar.getDeclaringFunction();
-            usedRegisters.clear();
-            if (declaringFunction.getParameterNames().contains(queryVar.getVarName())) {
-                // if the variable being queried is a parameter, we need to do some additional work to resolve
-                // what the parameter could point to.
-                int paramIndex = declaringFunction.getParameterNames().indexOf(queryVar.getVarName());
-
-                // For query value p, which is a parameter of some function,
-                // consult the call graph to determine what p could point to
-                Set<Value> argsPointingToQueryVar = callGraph
-                        .getCallers(declaringFunction)
-                        .stream()
-                        .map(callNode -> {
-                            try {
-                                int registerID = callNode.getArgRegister(paramIndex);
-                                return new Register(registerID, callNode.getBlock().getFunction());
-                            } catch (ArrayIndexOutOfBoundsException e) {
-                                // a call site may call a function with fewer than the required arguments
-                                return null;
-                            }
-                        })
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toSet());
-                invokes.forEach(invoke -> {
-                    argsPointingToQueryVar.forEach(argRegister -> {
-                        addCallPopState(invoke, argRegister);
+            invokes.forEach(invoke -> {
+                Function invokeScope = invoke.getBlock().getFunction();
+                // Closure handling
+                if (!queryVar.isVisibleIn(invokeScope)) {
+                    // If QueryVar isn't visible at the call site, we should move out one scope from the current
+                    // function and find what queryVar could point to in the invocation scope.
+                    getPredecessors(containingFunction.getNode()).forEach(pred -> {
+                        addSingleState(pred, queryVar);
                     });
-                });
-            } else {
-                invokes.forEach(invoke -> {
+                } else {
                     addCallPopState(invoke, queryVar);
-                });
-            }
+                }
+            });
         }
     }
 

--- a/src/test/java/com/amazon/pvar/tspoc/merlin/InterproceduralPointsToTests.java
+++ b/src/test/java/com/amazon/pvar/tspoc/merlin/InterproceduralPointsToTests.java
@@ -543,4 +543,26 @@ public class InterproceduralPointsToTests extends AbstractCallGraphTest{
         assert pts.contains(new ObjectAllocation(((NewObjectNode) getNodeByIndex(13, flowGraph))));
         assert pts.size() == 1;
     }
+
+    @Test
+    public void closureParamReassign() {
+        FlowGraph flowGraph =
+                initializeFlowgraph("src/test/resources/js/callgraph/interprocedural-tests/closureParamReassign.js");
+        dk.brics.tajs.flowgraph.jsnodes.Node queryNode = getNodeByIndex(36, flowGraph);
+        Value queryVal = new Variable("something", queryNode.getBlock().getFunction());
+        Node<NodeState, Value> initialQuery = new Node<>(
+                new NodeState(queryNode),
+                queryVal
+        );
+
+        BackwardMerlinSolver solver = MerlinSolverFactory.getNewBackwardSolver(initialQuery);
+        initializeQueryGraph(solver);
+        solver.solve();
+        Collection<Allocation> pts = solver.getPointsToGraph().getPointsToSet(queryNode, queryVal);
+
+        printPointsTo(queryVal, queryNode, pts);
+        assert pts.contains(new ObjectAllocation(((NewObjectNode) getNodeByIndex(23, flowGraph))));
+        assert pts.contains(new ObjectAllocation(((NewObjectNode) getNodeByIndex(8, flowGraph))));
+        assert pts.size() == 2;
+    }
 }

--- a/src/test/java/com/amazon/pvar/tspoc/merlin/InterproceduralPointsToTests.java
+++ b/src/test/java/com/amazon/pvar/tspoc/merlin/InterproceduralPointsToTests.java
@@ -565,4 +565,27 @@ public class InterproceduralPointsToTests extends AbstractCallGraphTest{
         assert pts.contains(new ObjectAllocation(((NewObjectNode) getNodeByIndex(8, flowGraph))));
         assert pts.size() == 2;
     }
+
+    @Test
+    public void closureDepth3() {
+        FlowGraph flowGraph =
+                initializeFlowgraph("src/test/resources/js/callgraph/interprocedural-tests/closureDepth3.js");
+        dk.brics.tajs.flowgraph.jsnodes.Node queryNode = getNodeByIndex(26, flowGraph);
+        Value queryVal = new Variable("res", queryNode.getBlock().getFunction());
+        Node<NodeState, Value> initialQuery = new Node<>(
+                new NodeState(queryNode),
+                queryVal
+        );
+
+        BackwardMerlinSolver solver = MerlinSolverFactory.getNewBackwardSolver(initialQuery);
+        initializeQueryGraph(solver);
+        solver.solve();
+        Collection<Allocation> pts = solver.getPointsToGraph().getPointsToSet(queryNode, queryVal);
+
+        printPointsTo(queryVal, queryNode, pts);
+        assert pts.contains(new ObjectAllocation(((NewObjectNode) getNodeByIndex(11, flowGraph))));
+        assert pts.contains(new ObjectAllocation(((NewObjectNode) getNodeByIndex(13, flowGraph))));
+        assert pts.contains(new ObjectAllocation(((NewObjectNode) getNodeByIndex(36, flowGraph))));
+        assert pts.size() == 3;
+    }
 }

--- a/src/test/resources/js/callgraph/interprocedural-tests/closureDepth3.js
+++ b/src/test/resources/js/callgraph/interprocedural-tests/closureDepth3.js
@@ -1,0 +1,22 @@
+function outer(a) {
+    function middle(b) {
+        var c = {};
+        function inner() {
+            if (a) {
+                return a;
+            } else if (b) {
+                return b;
+            } else {
+                return c;
+            }
+        }
+        return inner;
+    }
+    return middle;
+}
+
+var x = {};
+var y = {};
+var cl_middle = outer(x);
+var cl_inner = cl_middle(y);
+var res = cl_inner();

--- a/src/test/resources/js/callgraph/interprocedural-tests/closureParamReassign.js
+++ b/src/test/resources/js/callgraph/interprocedural-tests/closureParamReassign.js
@@ -1,0 +1,14 @@
+function bar(x) {
+    function foo() {
+        var something = x;
+        return something;
+    }
+    var res = foo();
+    x = {};
+    var res2 = foo();
+    return res;
+}
+
+var obj = {};
+
+var y = bar(obj);


### PR DESCRIPTION
*Issue #, if available:*
*Description of changes:*
- Remove incorrect handling of closures that assumed parameters of outer functions could not be reassigned
- Introduce a new and much simpler mechanism for tracking values in the lexical scope of closures:
  - If the flow function is applied to a variable `x` at the entry point of a nested function `f`, first find all possible call sites targeting `f`.
  - For each call site, determine if `x` is visible in the scope of the call site. If so, simply continue tracking the backward flow of `x` from the call site.
  - If `x` is not visible in the scope of the call site, continue tracking the backward flow of `x` from the end of `f`'s outer function. This will eventually find that allocation site that `x` points to at closure creation.
  - This approach works for multiply nested functions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
