### PR TITLE
Bundle node applications with rollup as part of eval-setup

### DIFF
--- a/scripts/evaluation/eval-setup.sh
+++ b/scripts/evaluation/eval-setup.sh
@@ -5,7 +5,6 @@ CURRENT_DIR=$(pwd)
 # Array of npm package names
 declare -a PACKAGES=(
     "makeappicon"
-    "toucht"
     "spotify-terminal"
     "ragan-module"
     "npm-git-snapshot"
@@ -15,6 +14,20 @@ declare -a PACKAGES=(
     "npmgenerate"
     "smrti"
     "openbadges-issuer"
+)
+
+# Associative array of benchmarks to their respective main files, using the benchmark directory as base for the relative path
+declare -A BENCHMARKS=(
+  ["makeappicon"]="lib/index.js" # Rollup works
+  ["spotify-terminal"]="src/control.js"
+  ["ragan-module"]="index.js"
+  ["npm-git-snapshot"]="index.js"
+  ["nodetree"]="index.js" # Rollup works
+  ["jwtnoneify"]="src/noneify.js"
+  ["foxx-framework"]="bin/foxxy"
+  ["npmgenerate"]="bin/ngen.js"
+  ["smrti"]="app.js" # Rollup works
+  ["openbadges-issuer"]="cli.js"
 )
 
 usage() {
@@ -44,11 +57,24 @@ if [ ! -d "eval-targets/node_modules" ] ; then
   echo "Could not successfully install packages. Is npm properly installed?" && exit 1
 fi
 
+# install rollup
+echo "Installing rollup for bundling of benchmark modules"
+npm install -g rollup &>/dev/null
+echo "Installing rollup plugins"
+npm install -g @rollup/plugin-node-resolve &>/dev/null
+npm install -g @rollup/plugin-json &>/dev/null
+npm install -g @rollup/plugin-commonjs &>/dev/null
+
 # package-level install
 for PACKAGE in "${PACKAGES[@]}"
 do
   echo "Installing ${PACKAGE} via npm"
   npm install --prefix "eval-targets/node_modules/${PACKAGE}" &>/dev/null
+  echo "bundling ${PACKAGE} with rollup"
+  cd "eval-targets/node_modules/${PACKAGE}"
+  # outputs a bundled file to eval-targets/node_modules/${PACKAGE}/bundle.js
+  rollup "${BENCHMARKS[$PACKAGE]}" --file bundle.js --format cjs -p node-resolve -p commonjs -p json
+  cd "${CURRENT_DIR}"
 done
 
 # Fix path errors in Jam's static-configuration.ts file


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add steps to install rollup and required plugins via npm to the `eval-setup.sh` script
- Run rollup on each benchmark to create a bundled file `bundle.js` in each benchmark directory.
- Remove `toucht` benchmark because it doesn't fit Merlin's use case. It is essentially a very thin node wrapper around the unix-like `touch` command.

*Open issues*
- Rollup currently only works correctly on three of the benchmarks (makeappicon, nodetree, and smrti). Perhaps @dtattersall could take a look and try to troubleshoot.
- The three successfully bundled benchmarks are runnable by Merlin, but they have exposed a few bugs. I will address the bugs in an upcoming PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
