### PR TITLE
Add JSON conversion function to CallGraph

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,11 @@ libraryDependencies += "commons-cli" % "commons-cli" % "1.4"
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.30"
 libraryDependencies += "org.slf4j" % "slf4j-simple" % "2.0.3" % Test
 
+// Printing to JSON
+// https://mvnrepository.com/artifact/com.google.code.gson/gson
+libraryDependencies += "com.google.code.gson" % "gson" % "2.10.1"
+
+
 Compile / run / mainClass := Some(
   "com.amazon.pvar.tspoc.merlin.experiments.Main"
 )

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/experiments/Location.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/experiments/Location.java
@@ -1,0 +1,4 @@
+package com.amazon.pvar.tspoc.merlin.experiments;
+
+public record Location(int line, int column) {
+}

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/experiments/SerializableCallGraph.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/experiments/SerializableCallGraph.java
@@ -1,0 +1,8 @@
+package com.amazon.pvar.tspoc.merlin.experiments;
+
+import java.util.Set;
+
+public record SerializableCallGraph(
+        Set<SerializableCallGraphEdge> edges
+) {
+}

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/experiments/SerializableCallGraphEdge.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/experiments/SerializableCallGraphEdge.java
@@ -1,0 +1,5 @@
+package com.amazon.pvar.tspoc.merlin.experiments;
+
+public record SerializableCallGraphEdge(Span callee, Span caller) {
+
+}

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/experiments/Span.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/experiments/Span.java
@@ -1,0 +1,4 @@
+package com.amazon.pvar.tspoc.merlin.experiments;
+
+public record Span(Location start, Location end, String file) {
+}

--- a/src/test/java/com/amazon/pvar/tspoc/merlin/CallGraphSerializationTests.java
+++ b/src/test/java/com/amazon/pvar/tspoc/merlin/CallGraphSerializationTests.java
@@ -1,0 +1,49 @@
+package com.amazon.pvar.tspoc.merlin;
+
+import com.amazon.pvar.tspoc.merlin.ir.FlowgraphUtils;
+import com.amazon.pvar.tspoc.merlin.solver.CallGraph;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import dk.brics.tajs.flowgraph.jsnodes.CallNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+
+public class CallGraphSerializationTests extends AbstractCallGraphTest {
+
+    @Test
+    public void canSerializeCallGraphsToJson() throws FileNotFoundException {
+        // arrange
+        final var testGraph = new CallGraph();
+        final var flowgraph = initializeFlowgraph("src/test/resources/js/callgraph/json-tests/callgraph-json-test.js");
+        final var barFunc = FlowgraphUtils.getFunctionByName(flowgraph, "bar").get();
+        final var callToFoo = (CallNode) FlowgraphUtils.allNodesInFunction(barFunc)
+                .filter(abstractNode -> abstractNode instanceof CallNode callNode && callNode.getTajsFunctionName() == null)
+                .findFirst()
+                .get();
+        final var fooFunc = FlowgraphUtils.getFunctionByName(flowgraph, "foo").get();
+        testGraph.addEdge(callToFoo, fooFunc);
+        final var gson = new Gson();
+        final var expectedJson = gson.fromJson(new FileReader("src/test/resources/js/callgraph/json-tests/callgraph-json-test.json"),
+                JsonElement.class);
+        // We need to replace the expected file by its absolute path, since CallGraph.toJSON is expected
+        // to produce absolute paths.
+        final var firstEdge = expectedJson.getAsJsonObject().get("edges").getAsJsonArray().get(0);
+        final var callee = firstEdge.getAsJsonObject().get("callee").getAsJsonObject();
+        final var sourceFile = "src/test/resources/js/callgraph/json-tests/_babel/callgraph-json-test.js";
+        final var absSourceFile = new File(sourceFile).getAbsolutePath();
+        callee.add("file", new JsonPrimitive(absSourceFile));
+        final var caller = firstEdge.getAsJsonObject().get("caller").getAsJsonObject();
+        caller.add("file", new JsonPrimitive(absSourceFile));
+
+        // act
+        final var asJson = testGraph.toJSON();
+
+        // assert
+        Assert.assertEquals(expectedJson, asJson);
+    }
+}

--- a/src/test/java/com/amazon/pvar/tspoc/merlin/experiments/SerializableCallGraphTest.java
+++ b/src/test/java/com/amazon/pvar/tspoc/merlin/experiments/SerializableCallGraphTest.java
@@ -1,0 +1,33 @@
+package com.amazon.pvar.tspoc.merlin.experiments;
+
+import com.google.gson.Gson;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.HashSet;
+
+public class SerializableCallGraphTest {
+
+    @Test
+    public void canBeParsedFromJSON() throws FileNotFoundException {
+        // arrange
+        final var sourceFile = "src/test/resources/js/callgraph/json-tests/_babel/callgraph-json-test.js";
+        final var expectedEdgeSet = new HashSet<SerializableCallGraphEdge>();
+        expectedEdgeSet.add(new SerializableCallGraphEdge(
+                new Span(new Location(1, 1), new Location(1, 18), sourceFile),
+                new Span(new Location(3, 3), new Location(3, 8), sourceFile)
+        ));
+        SerializableCallGraph expectedCallGraph = new SerializableCallGraph(expectedEdgeSet);
+        final var testFile = "src/test/resources/js/callgraph/json-tests/callgraph-json-test.json";
+
+        // act
+        final var gson = new Gson();
+        SerializableCallGraph fromJson = gson.fromJson(new FileReader(testFile), SerializableCallGraph.class);
+
+        // assert
+        Assert.assertEquals(expectedCallGraph, fromJson);
+    }
+
+}

--- a/src/test/resources/js/callgraph/json-tests/callgraph-json-test.js
+++ b/src/test/resources/js/callgraph/json-tests/callgraph-json-test.js
@@ -1,0 +1,7 @@
+function foo() {
+
+}
+
+function bar() {
+    foo();
+}

--- a/src/test/resources/js/callgraph/json-tests/callgraph-json-test.json
+++ b/src/test/resources/js/callgraph/json-tests/callgraph-json-test.json
@@ -1,0 +1,28 @@
+{
+  "edges": [
+    {
+      "callee": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        },
+        "file": "src/test/resources/js/callgraph/json-tests/_babel/callgraph-json-test.js"
+      },
+      "caller": {
+        "start": {
+          "line": 3,
+          "column": 3
+        },
+        "end": {
+          "line": 3,
+          "column": 8
+        },
+        "file": "src/test/resources/js/callgraph/json-tests/_babel/callgraph-json-test.js"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds the option of converting a call graph to a JSON representation (for comparison against other call graph generation tools), using Gson.