### PR TITLE
Upgrade simple-git to fix security issue

### DIFF
--- a/eval-jam/package.json
+++ b/eval-jam/package.json
@@ -30,7 +30,7 @@
     "lodash": "^4.17.15",
     "request": "^2.88.2",
     "semver": "^7.3.2",
-    "simple-git": "^2.12.0",
+    "simple-git": "^3.5.0",
     "source-map-support": "^0.5.19",
     "table": "^5.4.6",
     "tmp": "^0.2.1",


### PR DESCRIPTION
Note that this results in some tsc errors when building jam, due to breaking changes in simple-git's API. This appears to be in a utility package not required for building call graphs on projects that have already been fetched.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
