### PR TITLE
Implement support for method call syntax

### DIFF
--- a/src/main/java/com/amazon/pvar/tspoc/merlin/DebugUtils.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/DebugUtils.java
@@ -8,4 +8,8 @@ public class DebugUtils {
     public static void debug(final String str) {
         logger.debug(str);
     }
+
+    public static void warn(final String str) {
+        logger.warn(str);
+    }
 }

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/ir/FlowgraphUtils.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/ir/FlowgraphUtils.java
@@ -3,8 +3,11 @@ package com.amazon.pvar.tspoc.merlin.ir;
 import dk.brics.tajs.flowgraph.AbstractNode;
 import dk.brics.tajs.flowgraph.FlowGraph;
 import dk.brics.tajs.flowgraph.Function;
+import dk.brics.tajs.flowgraph.jsnodes.CallNode;
+import dk.brics.tajs.flowgraph.jsnodes.Node;
+import dk.brics.tajs.js2flowgraph.FlowGraphBuilder;
 
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Stream;
 
 public class FlowgraphUtils {
@@ -24,4 +27,20 @@ public class FlowgraphUtils {
                 .filter(function -> function.getName() != null && function.getName().equals(functionName))
                 .findFirst();
     }
+
+    public static Stream<Node> predecessorsOf(Node node) {
+        return predecessorMapCache
+                .computeIfAbsent(node.getBlock().getFunction(), FlowGraphBuilder::makeNodePredecessorMap)
+                .get(node)
+                .stream()
+                .filter(abstractNode -> abstractNode instanceof Node)
+                .map(abstractNode -> ((Node) abstractNode));
+    }
+
+    public static boolean isMethodCallWithStaticProperty(CallNode callNode) {
+        return callNode.getResultRegister() == -1 && callNode.getPropertyString() != null;
+    }
+
+    private final static Map<Function, Map<AbstractNode, Set<AbstractNode>>> predecessorMapCache = Collections.synchronizedMap(new HashMap<>());
+
 }

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/ir/MethodCall.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/ir/MethodCall.java
@@ -1,0 +1,40 @@
+package com.amazon.pvar.tspoc.merlin.ir;
+
+import dk.brics.tajs.flowgraph.jsnodes.CallNode;
+
+import java.util.Objects;
+
+/**
+ * An ad-hoc data flow fact to work around the issue that method calls in TAJS are represented
+ * by call nodes with an invalid function register, but with a property string instead. `MethodCall(callNode)`
+ * refers to the function invokes by `callNode` and is only introduced when resolving callees of
+ * such call nodes. This allows starting callee queries uniformly by starting from an appropriate
+ * initial SPDS state.
+ *
+ * A method call data flow fact is only expected to be generated at the same call node that it
+ * is referring to and is immediately translated into a push rule by `BackwardsFlowFunctions`. */
+public final class MethodCall extends Value {
+    private final CallNode callNode;
+
+    public MethodCall(CallNode callNode) {
+        assert FlowgraphUtils.isMethodCallWithStaticProperty(callNode);
+        this.callNode = callNode;
+    }
+
+    public CallNode getCallNode() {
+        return callNode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MethodCall that = (MethodCall) o;
+        return Objects.equals(callNode, that.callNode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(callNode);
+    }
+}

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/solver/QueryManager.scala
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/solver/QueryManager.scala
@@ -1,6 +1,6 @@
 package com.amazon.pvar.tspoc.merlin.solver
 
-import com.amazon.pvar.tspoc.merlin.ir.{Allocation, FunctionAllocation, NodeState, Register, Value}
+import com.amazon.pvar.tspoc.merlin.ir.{Allocation, FunctionAllocation, MethodCall, NodeState, Register, Value}
 import com.amazon.pvar.tspoc.merlin.livecollections.Scheduler
 import dk.brics.tajs.flowgraph.jsnodes.CallNode
 import sync.pds.solver.nodes.Node
@@ -78,14 +78,14 @@ class QueryManager() {
           reg.getId == callNode.getFunctionRegister &&
           reg.getContainingFunction == callNode.getBlock.getFunction =>
         this.getCallGraph.addEdge(callNode, functionAllocation.getAllocationStatement.getFunction)
+      case (callNode: CallNode, functionAllocation: FunctionAllocation, methodCall: MethodCall)
+        if callNode.equals(methodCall.getCallNode) =>
+        this.getCallGraph.addEdge(callNode, functionAllocation.getAllocationStatement.getFunction)
       case _ =>
     }
   }
 }
 
-/** Helper object to manage a single query manager via dynamic scoping rather
-  * than a singleton (simplifies testing)
-  */
 object QueryManager {
 
   type BackwardQuery = Node[NodeState, Value]

--- a/src/test/resources/js/callgraph/callgraph-tests/call-param-field-with-method-syntax.js
+++ b/src/test/resources/js/callgraph/callgraph-tests/call-param-field-with-method-syntax.js
@@ -1,0 +1,11 @@
+function invokeField(obj) {
+    obj.field(); // callees: 11
+}
+
+var x = {
+    field: foo
+};
+
+invokeField(x);
+
+function foo() {} // callers: 2

--- a/src/test/resources/js/callgraph/callgraph-tests/call-with-method-syntax.js
+++ b/src/test/resources/js/callgraph/callgraph-tests/call-with-method-syntax.js
@@ -1,0 +1,10 @@
+function call(func) { // callers: 7
+    func(); // callees: 9
+}
+
+var obj = {};
+obj.f = call;
+obj.f(foo); // callees: 1
+
+function foo() {} // callers: 2
+


### PR DESCRIPTION
Method calls in TAJS IR are represented differently than other function calls and contain an implicit field read. This commit adds support for the way method calls are represented by TAJS using a custom data flow fact representing queries to determine the target of method calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
