### PR TITLE
Track value flows through binary operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ After that, the project can be built by running `sbt compile` and run via `sbt r
 
 The test suite can be run using `sbt test`.
 
+### Missing Features
+
+Several JavaScript features are not implemented/analyzed by this prototype:
+
+- Loops
+- Prototype chains
+- Asynchronous code (`async/await`, `Promise`)
+- Built-in JavaScript functions
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/solver/flowfunctions/BackwardFlowFunctions.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/solver/flowfunctions/BackwardFlowFunctions.java
@@ -51,6 +51,14 @@ public class BackwardFlowFunctions extends AbstractFlowFunctions {
         final var resultReg = new Register(n.getResultRegister(), n.getBlock().getFunction());
         if (!getQueryValue().equals(resultReg)) {
             addNormalFlowToPreds(n);
+        } else {
+            // Overapproximate by adding flows to both arguments, since
+            // we don't model the actual operator semantics and tracking value flows through
+            // operators is needed for taint tracking examples in our case study.
+            final var arg1 = new Register(n.getArg1Register(), n.getBlock().getFunction());
+            final var arg2  = new Register(n.getArg2Register(), n.getBlock().getFunction());
+            genSingleNormalFlow(n, arg1);
+            genSingleNormalFlow(n, arg2);
         }
     }
 
@@ -395,6 +403,9 @@ public class BackwardFlowFunctions extends AbstractFlowFunctions {
         final var resultReg = new Register(n.getResultRegister(), n.getBlock().getFunction());
         if (!getQueryValue().equals(resultReg)) {
             addNormalFlowToPreds(n);
+        } else {
+            final var argRegister = new Register(n.getArgRegister(), n.getBlock().getFunction());
+            genSingleNormalFlow(n, argRegister);
         }
     }
 

--- a/src/test/resources/js/callgraph/callgraph-tests/flows-tracked-through-binary-operators.js
+++ b/src/test/resources/js/callgraph/callgraph-tests/flows-tracked-through-binary-operators.js
@@ -1,0 +1,9 @@
+var x = "abc";
+var y = "def";
+var z = x + y; // points-to: 1, 2
+
+function add(a, b) {
+    return a + b;
+}
+
+var result = add(x, y); // points-to: 1, 2


### PR DESCRIPTION
During backwards queries, flows through arguments of binary operators were not tracked, leading to missed flows for taint-tracking style analyses.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
