### PR TITLE
Migrating JAM evaluation to use wrapper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 eval-jam/node_modules/*
 scripts/evaluation/node_modules/*
+src/test/resources/js/**/_babel/*
+src/test/resources/js/**/*.flowgraph
 .bsp
 .idea
 .metals

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "tajs_vr"]
 	path = tajs_vr
 	url = git@github.com:cs-au-dk/tajs_vr.git
-[submodule "eval-jam/ISSTA-2021-Paper-156"]
-	path = eval-jam/ISSTA-2021-Paper-156
-	url = https://github.com/cs-au-dk/ISSTA-2021-Paper-156
 [submodule "ISSTA-2021-Paper-156"]
 	path = ISSTA-2021-Paper-156
 	url = https://github.com/cs-au-dk/ISSTA-2021-Paper-156

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ For example, if you are using using the Amazon Coretto SDK on Mac OSX, the follo
 
 ### Running Merlin
 
-After that, the project can be built by running `sbt compile` and run via `sbt run`.
+After that, the project can be built by running `sbt compile` and run via `sbt run`. From the command line, you can execute:
+```
+sbt "run --file path/to/js/file --output path/to/output/file"
+```
 
 The test suite can be run using `sbt test`.
 

--- a/eval-jam/README.md
+++ b/eval-jam/README.md
@@ -1,0 +1,33 @@
+## Overview
+
+This NPM package wraps JAM (ISSTA-2021-Paper-156/) and reformulates the output so that: 
+
+1. Edges that are not interesting to our evaluation are removed
+
+2. Edges are output in JSON format rather than .dot (graphviz) format
+
+
+## Building 
+
+1. Make sure that the JAM (ISSTA-2021-Paper-156) git submodule is checked out and you have run `npm install` in it
+
+2. In this `eval-jam` directory, run `npm install && npm run build`
+
+3. Check to make sure a `dist/` directory exists in this `eval-jam` directory
+
+## Running
+
+This is executed similar to JAM: 
+
+`cd dist/eval-jam/src && node index.js /path/to/node/module/to/analyze --client-main path/to/start/file --out ./path/to/the/json/output/file`
+
+Note that you must be in the `dist/eval-jam/src` directory, otherwise the relative path to the jam resources won't work. 
+This is due to a bug in JAM's package.json where it doesn't correctly export it's main files and resources.
+
+## Notes:
+
+* You can also pass `--help` and --debug` to the script
+
+* This is configured in our `package.json`, but eval-jam needs to specify the exact version of `logform` (2.4.2) otherwise the types exported
+by JAM won't work. This is due to the logform package moving on since development ceased on the paper repository. 
+

--- a/eval-jam/package.json
+++ b/eval-jam/package.json
@@ -2,11 +2,12 @@
   "name": "eval-jam",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/eval-jam/src/index.js",
   "scripts": {
     "tsc": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc"
+    "build": "npm run tsc && npm run copy-jam-resources",
+    "copy-jam-resources": "cp -R ../ISSTA-2021-Paper-156/res ./dist/res"
   },
   "author": "",
   "license": "ISC",
@@ -27,7 +28,9 @@
     "get-repository-url": "^2.0.0",
     "graphviz": "0.0.9",
     "is-builtin-module": "^3.0.0",
+    "jam": "file:../ISSTA-2021-Paper-156",
     "lodash": "^4.17.15",
+    "logform": "2.4.2",
     "request": "^2.88.2",
     "semver": "^7.3.2",
     "simple-git": "^3.5.0",
@@ -35,25 +38,15 @@
     "table": "^5.4.6",
     "tmp": "^0.2.1",
     "ts-option": "^2.1.0",
-    "winston": "^3.2.1"
+    "winston": "3.2.1"
   },
   "devDependencies": {
     "@persper/js-callgraph": "^1.3.2",
-    "@types/acorn": "4.0.5",
-    "@types/chai": "^4.2.3",
-    "@types/cytoscape": "^3.14.5",
     "@types/estree": "0.0.44",
     "@types/fs-extra": "^9.0.1",
-    "@types/lodash": "^4.14.155",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.7.9",
-    "@types/tmp": "^0.2.0",
-    "chai": "^4.2.0",
     "commander": "^5.1.0",
-    "husky": "^4.2.5",
-    "mocha": "^6.2.1",
-    "prettier": "^2.0.5",
-    "pretty-quick": "^2.0.1",
     "ts-node": "^8.6.2",
     "typescript": "^3.7.2"
   }

--- a/eval-jam/src/index.ts
+++ b/eval-jam/src/index.ts
@@ -1,8 +1,12 @@
 
 import { Position } from "estree";
-import { PropertyReadsOnLibraryObjectStrategies, ResolvedCallGraphNode, SimpleCallGraph } from "../ISSTA-2021-Paper-156/src/usage-model-generator/compute-call-graph";
-import { FunctionCreation } from "../ISSTA-2021-Paper-156/src/usage-model-generator/access-path";
-import { VulnerabilityScanner } from "../ISSTA-2021-Paper-156/src/call-graph/scanner";
+// Note: normally, since `jam` is declared as a dependency in the package.json we could just use `from "jam/src/..." here.
+// However, the ISSTA-2021-Paper-156 does not declare it's main js file or typings correctly in its package.json and so
+// the typescript compiler does not see the exported javascript thus while we use the types from node_modules/jam, we 
+// have to point to the actual typescript code directly 
+import { PropertyReadsOnLibraryObjectStrategies, ResolvedCallGraphNode, SimpleCallGraph } from "../../ISSTA-2021-Paper-156/src/usage-model-generator/compute-call-graph";
+import { FunctionCreation } from "../../ISSTA-2021-Paper-156/src/usage-model-generator/access-path";
+import { VulnerabilityScanner } from "../../ISSTA-2021-Paper-156/src/call-graph/scanner";
 import * as fs from "fs";
 import { resolve } from 'path';
 import commander from 'commander';
@@ -68,7 +72,7 @@ const callGraphToJSON = (cg: SimpleCallGraph): JsonCallGraph => {
 
 const writeJSONForCallGraph = (jsonCG: JsonCallGraph, jsonFile: fs.PathLike): void => {
   console.log(`Writing JSON call graph to ${jsonFile}`);
-  fs.writeFileSync(jsonFile, JSON.stringify(jsonCG));
+  fs.writeFileSync(jsonFile, JSON.stringify(jsonCG, undefined, 2));
 };
 
 

--- a/eval-jam/tsconfig.json
+++ b/eval-jam/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true, /* Enable all strict type-checking options. */
     "skipLibCheck": true, /* Skip type checking all .d.ts files. */
     "downlevelIteration": true, /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    "typeRoots": ["./node_modules/@types","./node_modules/jam/typings"], /* JAM in ISSTA-2021-Paper-156 has some important custom typings which our wrapper also needs */
     "lib": [
       "dom",
       "es5",
@@ -18,10 +19,6 @@
     "resolveJsonModule": true
   },
   "include": [
-    "src/**/*.ts",
-    /* Unfortunately, Jam cannot be used as an ordinary dependency, since it's not published to NPM and
-    adding the github repository as a dependency does not build the required JS files. Instead we
-    include its sources directly in our TypeScript build via git submodules. */
-    "ISSTA-2021-Paper-156"
+    "src/**/*.ts"
   ],
 }

--- a/scripts/evaluation/src/benchmark-utils.ts
+++ b/scripts/evaluation/src/benchmark-utils.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 
 const defaultEvaluationDir = path.resolve(__dirname, '..');
 
+export const projectRootDir = path.resolve(defaultEvaluationDir, '..', '..');
 export const getDynCgsDir = (rootDir = defaultEvaluationDir) => path.resolve(rootDir, "dyn_cgs");
 export const getJamCgsDir = (rootDir = defaultEvaluationDir) => path.resolve(rootDir, "jam_cgs");
 export const getBenchmarkModulesDir  = (rootDir = defaultEvaluationDir) =>  path.resolve(rootDir, "eval-targets", "node_modules")

--- a/scripts/evaluation/src/callgraphs.ts
+++ b/scripts/evaluation/src/callgraphs.ts
@@ -1,6 +1,7 @@
 import { execSync} from 'child_process';
+import { existsSync } from 'fs-extra';
 import * as path from "path";
-import { getBenchmarkMainFile, getBenchmarkModulePath } from './benchmark-utils';
+import { getBenchmarkMainFile, getBenchmarkModulePath, projectRootDir } from './benchmark-utils';
 
 // Jam expects an environment variable NODE_HOME pointing to GraalVM's node distribution
 export const getGraalNodePath = (nodeProfDir: string) => path.resolve(nodeProfDir, "graal", "sdk", "latest_graalvm_home");
@@ -18,7 +19,7 @@ export const runDynCg = (
 }
 
 export const runJam = (
-  jamPath: string,
+  jamPath: string, // temporarily not used while eval-jam/ script is not incorporated into this library
   graalNodeHome: string,
   benchmark: string,
   outputFile: string,
@@ -26,7 +27,13 @@ export const runJam = (
   moduleRootDir: string = getBenchmarkModulePath(benchmark)
 ) => {
   console.log(`Recording Jam CG for ${benchmark} into ${outputFile}`);
+  // Note: this was/will go back to ${jamPath}/dist/call-graph/index.js
+  const evalJamScript = path.resolve(projectRootDir, "eval-jam", "dist", "eval-jam", "src", "index.js");
+  if (!existsSync(evalJamScript)) {
+    throw new Error(`File ${evalJamScript} does not exist! Did you run 'npm install && npm run build' in the eval-jam directory?`);
+  }
   const startFile = path.relative(moduleRootDir, mainFile)
-  const jamCmd = `node ${jamPath}/dist/call-graph/index.js ${moduleRootDir} --client-main ${startFile} -o ${outputFile}`
+  const jamCmd=`node ${evalJamScript} ${moduleRootDir} --client-main ${startFile} -o ${outputFile}`
+  
   return execSync(jamCmd, {shell: '/bin/bash', env: { ...process.env, NODE_HOME: graalNodeHome }});
 };

--- a/scripts/evaluation/src/full-evaluation.ts
+++ b/scripts/evaluation/src/full-evaluation.ts
@@ -51,7 +51,7 @@ const generateJamCallGraphs = (jamPath: string, graalNodeHome: string, benchmark
 
   for (const benchmark of benchmarks) {
     try {
-      const outputFile = path.resolve(jamCallgraphOutDir, `${benchmark}.dot`);
+      const outputFile = path.resolve(jamCallgraphOutDir, `${benchmark}.json`);
       const resultBuffer = runJam(jamPath, graalNodeHome, benchmark, outputFile /* remaining defaults are okay */);
       console.log(resultBuffer.toString());
       generatedCallGraphs.push({ name: benchmark, outputFile: outputFile});


### PR DESCRIPTION
**Motivation:**

Jam outputs files in graphviz .dot which is not comparable to other tools. This converts the full evaluation script to use the Jam wrapper and output it in JSON

**Assumptions/Open issues:**

* It would be nice to combine the `eval-jam` javascript project as a library into our overall evaluation script

**Testing:**

* Ran eval-jam script separately and as part of the overall full-evaluation script

**Issue**

N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
