### PR TITLE
Track objects allocated with `new`

### DIFF
--- a/src/main/java/com/amazon/pvar/tspoc/merlin/ir/FlowgraphUtils.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/ir/FlowgraphUtils.java
@@ -38,7 +38,7 @@ public class FlowgraphUtils {
     }
 
     public static boolean isMethodCallWithStaticProperty(CallNode callNode) {
-        return callNode.getResultRegister() == -1 && callNode.getPropertyString() != null;
+        return callNode.getFunctionRegister() == -1 && callNode.getPropertyString() != null;
     }
 
     private final static Map<Function, Map<AbstractNode, Set<AbstractNode>>> predecessorMapCache = Collections.synchronizedMap(new HashMap<>());

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/solver/BackwardMerlinSolver.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/solver/BackwardMerlinSolver.java
@@ -79,9 +79,18 @@ public class BackwardMerlinSolver extends MerlinSolver {
                                         initialQuery.fact(), objAlloc
                                 );
                             }
+                        } else if (tajsNode instanceof CallNode callNode && 
+                                callNode.isConstructorCall() &&
+                                node.fact() instanceof Register register &&
+                                register.getId() == callNode.getResultRegister() &&
+                                register.getContainingFunction().equals(callNode.getBlock().getFunction())) {
+                            final var objAlloc = new ObjectAllocation(callNode);
+                            queryManager.addPointsToFact(initialQuery.stmt().getNode(), initialQuery.fact(),
+                                    objAlloc);
                         } else if (tajsNode instanceof ConstantNode constantNode &&
                                 node.fact() instanceof Register register) {
-                            if (constantNode.getResultRegister() == register.getId()) {
+                            if (constantNode.getResultRegister() == register.getId() &&
+                                    register.getContainingFunction().equals(tajsNode.getBlock().getFunction())) {
                                 ConstantAllocation constantAllocation = new ConstantAllocation(constantNode);
                                 queryManager.addPointsToFact(
                                         initialQuery.stmt().getNode(),

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/solver/flowfunctions/BackwardFlowFunctions.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/solver/flowfunctions/BackwardFlowFunctions.java
@@ -105,9 +105,17 @@ public class BackwardFlowFunctions extends AbstractFlowFunctions {
             return;
         }
 
+        // If the call is a constructor call, kill the flow if the query value matches
+        if (n.isConstructorCall() &&
+                n.getResultRegister() != 1 &&
+                context.queryValue() instanceof Register reg &&
+                reg.getId() == n.getResultRegister() &&
+                reg.getContainingFunction().equals(n.getBlock().getFunction())) {
+            return;
+        }
+
         // propagate the assigned value to the return value of possibly invoked
         // functions, if necessary
-
         if (context.queryValue().equals(resultReg) ||
                 context.queryValue() instanceof ObjectAllocation) {
             final var targetFunctions = resolveFunctionCall(n);

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/solver/flowfunctions/ForwardFlowFunctions.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/solver/flowfunctions/ForwardFlowFunctions.java
@@ -540,7 +540,7 @@ public class ForwardFlowFunctions extends AbstractFlowFunctions {
 
         if (context.queryValue().equals(argRegister) || // ad-hoc fix:
                 context.queryValue() instanceof ObjectAllocation objAlloc
-                        && objAlloc.getAllocationStatement().getResultRegister() == n.getValueRegister()) {
+                        && objAlloc.getResultRegister().getId() == n.getValueRegister()) {
             genSingleNormalFlow(n, write);
 
             // If the variable we are writing to flows to a closure, we also need to

--- a/src/test/java/com/amazon/pvar/tspoc/merlin/CallGraphTests.java
+++ b/src/test/java/com/amazon/pvar/tspoc/merlin/CallGraphTests.java
@@ -189,12 +189,15 @@ public final class CallGraphTests {
                 .filter(node -> node.getSourceLocation() != null && node.getSourceLocation().getLineNumber() == lineNo)
                 .toList();
         final Stream<Allocation> objectAllocs = nodesOnLine.stream().filter(node -> node instanceof NewObjectNode)
-                .map(newObjectNode -> new ObjectAllocation((NewObjectNode) newObjectNode));
+                .map(newObjectNode -> new ObjectAllocation((dk.brics.tajs.flowgraph.jsnodes.Node) newObjectNode));
+        final Stream<Allocation> constructorAllocs = nodesOnLine.stream().filter(node -> node instanceof CallNode callNode &&
+                callNode.isConstructorCall())
+                .map(callNode -> new ObjectAllocation((dk.brics.tajs.flowgraph.jsnodes.Node) callNode));
         final Stream<Allocation> constAllocs = nodesOnLine.stream().filter(node -> node instanceof ConstantNode)
                 .map(constNode -> new ConstantAllocation((ConstantNode) constNode));
         final Stream<Allocation> funcAllocs = nodesOnLine.stream().filter(node -> node instanceof DeclareFunctionNode)
                 .map(funcNode -> new FunctionAllocation((DeclareFunctionNode) funcNode));
-        final var allAllocs = Stream.concat(objectAllocs, Stream.concat(constAllocs, funcAllocs));
+        final var allAllocs = Stream.concat(Stream.concat(objectAllocs, constructorAllocs), Stream.concat(constAllocs, funcAllocs));
         return ensureOneElementIn(
                 allAllocs,
                 "Ambiguous allocations on line " + lineNo + ": " + allAllocs

--- a/src/test/resources/js/callgraph/callgraph-tests/call-field-on-new-alloc.js
+++ b/src/test/resources/js/callgraph/callgraph-tests/call-field-on-new-alloc.js
@@ -1,0 +1,7 @@
+var obj = new foo();
+obj.field = bar;
+obj.field(); // callees: 6
+
+function foo() {}
+function bar() {} // callers: 3
+

--- a/src/test/resources/js/callgraph/callgraph-tests/track-new-allocs.js
+++ b/src/test/resources/js/callgraph/callgraph-tests/track-new-allocs.js
@@ -1,0 +1,4 @@
+var obj = new foo();
+var x = obj; // points-to: 1
+
+function foo() {}


### PR DESCRIPTION
*Note*: Depends on https://github.com/amzn/merlin-on-demand-callgraph/pull/21, please review that one first.

Previously, only `NewObjectNode`s (i.e. object literals such as `{}`) were treated as allocations and tracked by the points-to analysis. this commit adds tracking for objects allocated by `new`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
