### PR TITLE
Add data flow between result and arguments for unresolved calls

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ libraryDependencies += "org.jgrapht" % "jgrapht-io" % "1.5.1"
 // https://mvnrepository.com/artifact/org.jgrapht/jgrapht-ext
 libraryDependencies += "org.jgrapht" % "jgrapht-ext" % "1.5.1"
 
-Compile / run / mainClass := Some(
+Compile / mainClass := Some(
   "com.amazon.pvar.tspoc.merlin.experiments.Main"
 )
 
@@ -84,3 +84,5 @@ libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test
 
 Compile / doc / sources := Seq.empty
 Compile / packageDoc / publishArtifact := false
+
+enablePlugins(JavaAppPackaging)

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/experiments/Main.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/experiments/Main.java
@@ -216,6 +216,7 @@ public class Main {
                 e.printStackTrace();
             }
         });
+        queryManager.solve();
         timer.stop();
         ExperimentUtils.Statistics.incrementTotalTime(timer.getTotalElapsed());
         ExperimentUtils.Statistics.incrementCGEdgesFound(cg.size());

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/solver/BackwardMerlinSolver.java
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/solver/BackwardMerlinSolver.java
@@ -224,10 +224,6 @@ public class BackwardMerlinSolver extends MerlinSolver {
         );
     }
 
-    public boolean isFunctionQuery() {
-        return isFunctionQuery;
-    }
-
     public void setFunctionQuery(boolean functionQuery) {
         isFunctionQuery = functionQuery;
     }

--- a/src/main/java/com/amazon/pvar/tspoc/merlin/solver/QueryManager.scala
+++ b/src/main/java/com/amazon/pvar/tspoc/merlin/solver/QueryManager.scala
@@ -84,6 +84,24 @@ class QueryManager() {
       case _ =>
     }
   }
+
+  /** Run all solvers to completion */
+  def solve(): Unit = {
+    scheduler.waitUntilDone()
+    var stillIterating = true
+    // After solving, we still need to handle unresolved function calls, which may each
+    // trigger additional flows in other solvers leading to more unresolved calls. We handle
+    // this by computing the fixed point of repeatedly adding data flows for unresolved
+    // calls until no new data flows are found
+    while (stillIterating) {
+      stillIterating = false
+      for (solver <- backwardSolvers.values ++ forwardSolvers.values) {
+          if(solver.addDataFlowsForUnresolvedFunctionCalls()) {
+            stillIterating = true
+          }
+      }
+    }
+  }
 }
 
 object QueryManager {

--- a/src/test/java/com/amazon/pvar/tspoc/merlin/CallGraphTests.java
+++ b/src/test/java/com/amazon/pvar/tspoc/merlin/CallGraphTests.java
@@ -98,7 +98,7 @@ public final class CallGraphTests {
                 funcAlloc
         );
         final var solver = queryManager.getOrStartForwardQuery(initialQuery);
-        solver.solve();
+        queryManager.solve();
         queryManager.scheduler().waitUntilDone();
         final var callGraph = queryManager.getCallGraph();
         final var actualCallers = callGraph
@@ -130,7 +130,7 @@ public final class CallGraphTests {
                 findAllocs.value()
         );
         final var solver = queryManager.getOrStartBackwardQuery(initialQuery);
-        solver.solve();
+        queryManager.solve();
         final var pointsToSet = queryManager.getPointsToGraph().getPointsToSet(findAllocs.node(), findAllocs.value());
         assertThat(pointsToSet.toJavaSet(), equalTo(findAllocs.expectedAllocations()));
     }

--- a/src/test/java/com/amazon/pvar/tspoc/merlin/InterproceduralPointsToTests.java
+++ b/src/test/java/com/amazon/pvar/tspoc/merlin/InterproceduralPointsToTests.java
@@ -226,7 +226,7 @@ public class InterproceduralPointsToTests extends AbstractCallGraphTest {
         final var queryManager = new QueryManager();
         BackwardMerlinSolver solver = queryManager.getOrStartBackwardQuery(initialQuery);
         Collection<Allocation> pts = solver.getPointsToGraph().getPointsToSet(queryNode, queryVal).toJavaSet();
-        queryManager.scheduler().waitUntilDone();
+        queryManager.solve();
         printPointsTo(queryVal, queryNode, pts);
         assert pts.contains(new ObjectAllocation(((NewObjectNode) getNodeByIndex(16, flowGraph)))) &&
                         pts.contains(new ConstantAllocation(((ConstantNode) getNodeByIndex(43, flowGraph))));
@@ -639,8 +639,7 @@ public class InterproceduralPointsToTests extends AbstractCallGraphTest {
         );
         final var queryManager = new QueryManager();
         final var solver = queryManager.getOrStartForwardQuery(initialQuery);
-        solver.solve();
-        queryManager.scheduler().waitUntilDone();
+        queryManager.solve();
         final var pointsToLocations = queryManager.getPointsToGraph().getKnownValuesPointingTo((Allocation)queryVal).toJavaSet();
         printPointsToLocations(queryVal, queryNode, pointsToLocations);
         final var resultLocation = new PointsToGraph.PointsToLocation(
@@ -690,7 +689,7 @@ public class InterproceduralPointsToTests extends AbstractCallGraphTest {
         );
         final var queryManager = new QueryManager();
         BackwardMerlinSolver solver = queryManager.getOrCreateBackwardSolver(initialQuery);
-        solver.solve();
+        queryManager.solve();
         Collection<Allocation> pts = solver.getPointsToGraph().getPointsToSet(queryNode, queryVal).toJavaSet();
 
         printPointsTo(queryVal, queryNode, pts);

--- a/src/test/resources/js/callgraph/callgraph-tests/track-flows-across-unresolved-calls.js
+++ b/src/test/resources/js/callgraph/callgraph-tests/track-flows-across-unresolved-calls.js
@@ -1,0 +1,8 @@
+var x = "abc";
+var result = String(x); // points-to: 1
+
+
+var x = id(foo); // id is undefined but the result should depend on foo
+x();
+
+function foo() {} // callers: 6

--- a/src/test/resources/js/callgraph/callgraph-tests/unresolved-call-introducing-dataflow-to-another-unresolved-call.js
+++ b/src/test/resources/js/callgraph/callgraph-tests/unresolved-call-introducing-dataflow-to-another-unresolved-call.js
@@ -1,0 +1,5 @@
+var x = unresolved(foo);
+var y = unresolved2(x);
+y(); // callees: 5
+
+function foo() {} // callers: 3


### PR DESCRIPTION
Some function calls may remain unresolved, for example in the case of JavaScript builtins or missing dependency code. While the proper fix is to model all JavaScript builtins, this commit first implements a "somewhat less unsound" workaround that assumes data flow between arguments and results (depending on analysis direction) that captures the behavior of some JS builtins such as `String(..)`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
